### PR TITLE
ログインAPIの定義について、レスポンスにuser_idとexpを追加した

### DIFF
--- a/generated-api/apis/IntrospectionApi.ts
+++ b/generated-api/apis/IntrospectionApi.ts
@@ -28,17 +28,17 @@ import {
     StacksIntrospectionsIntrospectionToJSON,
 } from '../models';
 
-interface ApiV1StacksIntrospectionsCreateRequest {
+export interface ApiV1StacksIntrospectionsCreateRequest {
     stackId: number;
     stacksIntrospectionCreateRequestBody: StacksIntrospectionCreateRequestBody;
 }
 
-interface ApiV1StacksIntrospectionsShowRequest {
+export interface ApiV1StacksIntrospectionsShowRequest {
     stackId: number;
     introspectionId: number;
 }
 
-interface ApiV1StacksIntrospectionsUpdateRequest {
+export interface ApiV1StacksIntrospectionsUpdateRequest {
     stackId: number;
     introspectionId: number;
     stacksIntrospectionUpdateRequestBody: StacksIntrospectionUpdateRequestBody;

--- a/generated-api/apis/StackApi.ts
+++ b/generated-api/apis/StackApi.ts
@@ -37,21 +37,21 @@ import {
     StacksStackListInnerToJSON,
 } from '../models';
 
-interface ApiV1StacksCreateRequest {
+export interface ApiV1StacksCreateRequest {
     stacksCreateRequestBody: StacksCreateRequestBody;
 }
 
-interface ApiV1StacksIntrospectionsCreateRequest {
+export interface ApiV1StacksIntrospectionsCreateRequest {
     stackId: number;
     stacksIntrospectionCreateRequestBody: StacksIntrospectionCreateRequestBody;
 }
 
-interface ApiV1StacksIntrospectionsShowRequest {
+export interface ApiV1StacksIntrospectionsShowRequest {
     stackId: number;
     introspectionId: number;
 }
 
-interface ApiV1StacksIntrospectionsUpdateRequest {
+export interface ApiV1StacksIntrospectionsUpdateRequest {
     stackId: number;
     introspectionId: number;
     stacksIntrospectionUpdateRequestBody: StacksIntrospectionUpdateRequestBody;

--- a/generated-api/models/AuthLogin.ts
+++ b/generated-api/models/AuthLogin.ts
@@ -31,6 +31,18 @@ export interface AuthLogin {
      * @memberof AuthLogin
      */
     accessToken: string;
+    /**
+     * ユーザーID
+     * @type {number}
+     * @memberof AuthLogin
+     */
+    userId?: number;
+    /**
+     * 有効期限切れまでの秒数
+     * @type {number}
+     * @memberof AuthLogin
+     */
+    exp?: number;
 }
 
 /**
@@ -56,6 +68,8 @@ export function AuthLoginFromJSONTyped(json: any, ignoreDiscriminator: boolean):
         
         'tokenType': json['token_type'],
         'accessToken': json['access_token'],
+        'userId': !exists(json, 'user_id') ? undefined : json['user_id'],
+        'exp': !exists(json, 'exp') ? undefined : json['exp'],
     };
 }
 
@@ -70,6 +84,8 @@ export function AuthLoginToJSON(value?: AuthLogin | null): any {
         
         'token_type': value.tokenType,
         'access_token': value.accessToken,
+        'user_id': value.userId,
+        'exp': value.exp,
     };
 }
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -9,7 +9,7 @@ servers:
     description: Development server
   - url: https://skill-climbing.onrender.com
     description: Production server
-    
+
 paths:
   /api/login:
     post:
@@ -223,7 +223,7 @@ paths:
           description: ユーザーが存在しない
         '422':
           description: バリデーションエラー
-      
+
     patch:
       summary: ユーザーデータ更新
       operationId: api.v1.users.update
@@ -299,16 +299,29 @@ components:
           allOf:
             - $ref: '#/components/schemas/Auth_Login_AccessToken'
           nullable: false
-          
+        user_id:
+          allOf:
+            - $ref: '#/components/schemas/Users_User_Id'
+          nullable: false
+        exp:
+          allOf:
+            - $ref: '#/components/schemas/Auth_Login_Exp'
+          nullable: false
+
     Auth_Login_TokenType:
       type: string
       description: アクセストークンタイプ
       example: Bearer
-      
+
     Auth_Login_AccessToken:
       type: string
       description: アクセストークン
       example: access_token
+
+    Auth_Login_Exp:
+      type: integer
+      description: 有効期限切れまでの秒数
+      example: 123456
 
     Stacks_StackList:
       type: array
@@ -697,7 +710,7 @@ components:
       type: string
       format: date-time
       example: '2023-01-01T00:00:00+09:00'
-      
+
     AuthLoginRequestBody:
       type: object
       required:


### PR DESCRIPTION
## Epic
[認証機能をRails側で実装する](https://app.asana.com/0/1204548322306328/1205352883161236/f)

## PBI
ログインAPIのレスポンスにユーザーIDを含めるようにする

## OpenAPI
本PR

## 対象画面キャプチャ
なし

## やったこと
- ログインAPIの定義について、レスポンスにuser_idとexpを追加した

## このPRでやらないこと
- 

## 動作確認
- [x] 確認済み

## その他
- 
