### PR TITLE
積み上げ情報とユーザー情報を紐付けるためにAPI定義を修正した

### DIFF
--- a/generated-api/apis/StackApi.ts
+++ b/generated-api/apis/StackApi.ts
@@ -41,6 +41,10 @@ export interface ApiV1StacksCreateRequest {
     stacksCreateRequestBody: StacksCreateRequestBody;
 }
 
+export interface ApiV1StacksIndexRequest {
+    userId: number;
+}
+
 export interface ApiV1StacksIntrospectionsCreateRequest {
     stackId: number;
     stacksIntrospectionCreateRequestBody: StacksIntrospectionCreateRequestBody;
@@ -98,8 +102,16 @@ export class StackApi extends runtime.BaseAPI {
     /**
      * 積み上げ一覧
      */
-    async apiV1StacksIndexRaw(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<StacksStackListInner>>> {
+    async apiV1StacksIndexRaw(requestParameters: ApiV1StacksIndexRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<Array<StacksStackListInner>>> {
+        if (requestParameters.userId === null || requestParameters.userId === undefined) {
+            throw new runtime.RequiredError('userId','Required parameter requestParameters.userId was null or undefined when calling apiV1StacksIndex.');
+        }
+
         const queryParameters: any = {};
+
+        if (requestParameters.userId !== undefined) {
+            queryParameters['user_id'] = requestParameters.userId;
+        }
 
         const headerParameters: runtime.HTTPHeaders = {};
 
@@ -116,8 +128,8 @@ export class StackApi extends runtime.BaseAPI {
     /**
      * 積み上げ一覧
      */
-    async apiV1StacksIndex(initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<StacksStackListInner>> {
-        const response = await this.apiV1StacksIndexRaw(initOverrides);
+    async apiV1StacksIndex(requestParameters: ApiV1StacksIndexRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<Array<StacksStackListInner>> {
+        const response = await this.apiV1StacksIndexRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/generated-api/models/StacksCreateRequestBody.ts
+++ b/generated-api/models/StacksCreateRequestBody.ts
@@ -38,6 +38,12 @@ export interface StacksCreateRequestBody {
      */
     skillId: number;
     /**
+     * ユーザーID
+     * @type {number}
+     * @memberof StacksCreateRequestBody
+     */
+    userId: number;
+    /**
      * 積み上げ内容
      * @type {string}
      * @memberof StacksCreateRequestBody
@@ -59,6 +65,7 @@ export function instanceOfStacksCreateRequestBody(value: object): boolean {
     isInstance = isInstance && "title" in value;
     isInstance = isInstance && "minutes" in value;
     isInstance = isInstance && "skillId" in value;
+    isInstance = isInstance && "userId" in value;
     isInstance = isInstance && "description" in value;
     isInstance = isInstance && "stackedAt" in value;
 
@@ -78,6 +85,7 @@ export function StacksCreateRequestBodyFromJSONTyped(json: any, ignoreDiscrimina
         'title': json['title'],
         'minutes': json['minutes'],
         'skillId': json['skill_id'],
+        'userId': json['user_id'],
         'description': json['description'],
         'stackedAt': (new Date(json['stacked_at'])),
     };
@@ -95,6 +103,7 @@ export function StacksCreateRequestBodyToJSON(value?: StacksCreateRequestBody | 
         'title': value.title,
         'minutes': value.minutes,
         'skill_id': value.skillId,
+        'user_id': value.userId,
         'description': value.description,
         'stacked_at': (value.stackedAt.toISOString()),
     };

--- a/openapi.yml
+++ b/openapi.yml
@@ -43,6 +43,12 @@ paths:
       tags:
         - Stack
       security: []
+      parameters:
+        - name: user_id
+          in: query
+          required: true
+          schema:
+            $ref: '#/components/schemas/Users_User_Id'
       responses:
         '200':
           description: 成功

--- a/openapi.yml
+++ b/openapi.yml
@@ -738,6 +738,7 @@ components:
         - title
         - minutes
         - skill_id
+        - user_id
         - description
         - stacked_at
       properties:
@@ -752,6 +753,10 @@ components:
         skill_id:
           allOf:
             - $ref: '#/components/schemas/Skills_Skill_Id'
+          nullable: false
+        user_id:
+          allOf:
+            - $ref: '#/components/schemas/Users_User_Id'
           nullable: false
         description:
           allOf:


### PR DESCRIPTION
## Epic
[本番環境で基本的な機能が使えるようになっている](https://app.asana.com/0/1204548322306328/1205352883161224/f)

## PBI
[積み上げ情報とユーザー情報を紐付ける](https://app.asana.com/0/1204548322306328/1205561525261600/f)

## OpenAPI
本PR

## 対象画面キャプチャ
なし

## やったこと
- 積み上げ一覧APIをユーザーIDで絞り込めるようにパラメーターを渡すようにした
- 積み上げ作成時にuser_idも登録できるようにパラメーターを追加した

@ren0826nosuke

## このPRでやらないこと
なし

## 動作確認
- [ ] 確認済み

## その他
なし