### PR TITLE
ユーザー更新でチームを登録できるようにした

### DIFF
--- a/components/molecules/FormModal.tsx
+++ b/components/molecules/FormModal.tsx
@@ -40,7 +40,7 @@ const FormModal: FC = () => {
       setValue('name', '')
       setValue('email', '')
       setValue('profile_content', '')
-      setValue('team', '')
+      setValue('team', 0)
     }
   }
 
@@ -71,7 +71,7 @@ const FormModal: FC = () => {
       }
     }
 
-    let checkAlert = window.confirm();
+    let checkAlert = false;
     let params = {}
 
     if (formType === 'createStack') {
@@ -84,15 +84,22 @@ const FormModal: FC = () => {
         stacked_at: data.date,
         user_id: sessionData.userId
       }
+
+      axios.post(`${process.env.API_ROOT_URL}/api/v1/stacks`, params, options)
+      .then(response => {
+        router.push('/timeline')
+      })
+      .catch(error => {
+        throw new Error(`${JSON.stringify(error)}`);
+      });
     }
 
-    axios.post(`${process.env.API_ROOT_URL}/api/v1/stacks`, params, options)
-    .then(response => {
-      router.push('/timeline')
-    })
-    .catch(error => {
-      throw new Error(`${JSON.stringify(error)}`);
-    });
+    if (formType === 'updateUser') {
+      checkAlert = window.confirm('ユーザー情報を更新しますか？');
+      console.log(data)
+      // TODO: APIで更新処理
+    }
+
     resetValue(checkAlert);
   }
 

--- a/components/molecules/TextInput.tsx
+++ b/components/molecules/TextInput.tsx
@@ -5,9 +5,13 @@ import TextField from '@mui/material/TextField';
 
 import { TextInputProps } from '@/types/types';
 
-const TextInput: FC<TextInputProps> = ({ control, name, fullWidth, multiline, minRows, required, requiredMessage, label, placeholder, type }) => {
+const TextInput: FC<TextInputProps> = ({ control, name, fullWidth, multiline, minRows, required, requiredMessage, label, placeholder, type, onChange, onClick, value  }) => {
   return (
-    <Box className="mt-4">
+    <Box 
+      className="mt-4"
+      onChange={onChange}
+      onClick={onClick}
+    >
       <Controller
         name={name}
         control={control}
@@ -25,6 +29,7 @@ const TextInput: FC<TextInputProps> = ({ control, name, fullWidth, multiline, mi
             error={!!fieldState?.error}
             helperText={fieldState?.error?.message as string}
             type={type}
+            value={value}
           />
         )}
       />

--- a/components/molecules/UserFormGroup.tsx
+++ b/components/molecules/UserFormGroup.tsx
@@ -1,8 +1,52 @@
-import React, { FC, useEffect } from 'react'
+import React, { FC, useState, useEffect } from 'react'
 import TextInput from './TextInput';
-import { ControlAndSetValueProps } from '../../types/types';
+import { ControlAndSetValueProps, ApiOptions, Team } from '../../types/types';
+import { getSession } from '@/utiliry/session';
+import axios from 'axios';
 
-const UserFormGroup: FC<ControlAndSetValueProps> = ({ control }) => {
+const UserFormGroup: FC<ControlAndSetValueProps> = ({ control, setValue }) => {
+  const [query, setQuery] = useState<string>('');
+  const [results, setResults] = useState<Team[]>([]);
+  const [showResults, setShowResults] = useState<boolean>(false);
+  const [teamValue, setTeamValue] = useState<string|number>("");
+
+  const handleTextInputClick = () => {
+    setShowResults(true);
+  };
+  const handleTeamChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value)
+    setTeamValue(e.target.value);
+  };
+  const handleTeamClick = (team: Team) => {
+    setValue('team', team.id);
+    setTeamValue(team.name);
+    setShowResults(false);
+  }
+
+  useEffect(() => {
+    const fetchTeams = async (query: string) => {
+      const sessionData = getSession();
+      if (!sessionData) return;
+  
+      const options: ApiOptions<{name: string}> = {
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${sessionData.token}`
+        },
+        params: query ? { name: query } : undefined
+      }
+  
+      try {
+        const response = await axios.get(`${process.env.API_ROOT_URL}/api/v1/teams`, options);
+        return response.data.teams;
+      } catch (error) {
+        throw new Error(`${JSON.stringify(error)}`);
+      }
+    };
+
+    fetchTeams(query).then(res => setResults(res));
+  }, [query])
+
   return (
     <>
       <TextInput
@@ -52,10 +96,23 @@ const UserFormGroup: FC<ControlAndSetValueProps> = ({ control }) => {
         minRows={1}
         required={true}
         requiredMessage={"必須入力"}
-        label={"グループ"}
-        placeholder={"グループ1"}
+        label={"チーム"}
+        placeholder={"チームを選択してください"}
         type='text'
+        onChange={(e) => handleTeamChange(e)}
+        onClick={handleTextInputClick}
+        value={teamValue}
       />
+      {showResults && (
+        <div className="max-h-[120px] overflow-y-auto">
+          {results.map((team: Team) => (
+            <div key={team.id} onClick={() => handleTeamClick(team)} className='cursor-pointer hover:bg-gray-100 py-2 px-2 bg-gray-50'>
+              {team.name}
+            </div>
+          ))}
+        </div>
+      )}
+
     </>
   )
 }

--- a/types/types.ts
+++ b/types/types.ts
@@ -104,7 +104,7 @@ export type UserUpdateRequestBody = {
   name: string;
   email: string;
   profile_content: string;
-  team: string;
+  team: number;
 }
 
 export type FormDataParams = StacksCreateRequestBody & StacksIntrospectionRequestBody & UserUpdateRequestBody;
@@ -137,6 +137,9 @@ export type TextInputProps = ControlProps & {
   label: string;
   placeholder: string;
   type: string;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>; 
+  onClick?: React.MouseEventHandler<HTMLDivElement>;
+  value?: string | number
 }
 
 export type IntrospectionProps = {
@@ -190,18 +193,20 @@ export type sessionUser = {
   profile_content: string;
   created_at: string;
   updated_at: string;
-  team:{
-    id: number;
-    name: string;
-    created_at: string;
-    updated_at: string;
-  }
+  team: Team
 } | undefined
 
-export type ApiOptions<T extends Record<string, number> = {}> = {
+export type ApiOptions<T extends Record<string, string | number> = {}> = {
   headers: {
     'Content-Type': string;
     'Authorization': string;
   };
   params?: T;
 };
+
+export type Team = {
+  id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
## Epic
[ユーザーをグルーピングできるようにする](https://app.asana.com/0/1204548322306328/1205352883161259/f)

## PBI
[ユーザー詳細ページでチームを登録できるようにする](https://app.asana.com/0/1204548322306328/1205352883161388/f)

## OpenAPI
なし

## 対象画面キャプチャ
![スクリーンショット 2023-09-29 13 12 20](https://github.com/mnmuu8/skill-climbing-frontend/assets/121008362/cbaa7d9a-c762-4313-9b2b-9cda49d410d7)

今は一つしかないので分かりづらいですが、3つ以上の時はスクロールできるようになってます

## やったこと
- ユーザー詳細ページでチームを登録できるようにする
  - インクリメンタルサーチで正しくチームが取得できる
  - ユーザー更新時に任意のチームに所属させることができる
  - 日本語で「グループ」となってる部分も「チーム」に修正されている
 
## このPRでやらないこと
なし

## 動作確認
- [x] 確認済み

## その他
なし