### PR TITLE
積み上げの反省閲覧と作成機能作成

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["next/core-web-vitals", "prettier"]
+  "extends": ["next/core-web-vitals", "prettier"],
+  "rules": {
+    "react-hooks/exhaustive-deps": "off"
+  }
 }

--- a/components/molecules/StackCard.tsx
+++ b/components/molecules/StackCard.tsx
@@ -4,7 +4,7 @@ import LocalOfferIcon from '@mui/icons-material/LocalOffer';
 import FavoriteBorderIcon from '@mui/icons-material/FavoriteBorder';
 import BookmarkBorderIcon from '@mui/icons-material/BookmarkBorder';
 import { formatDate } from '../uikit/dateUtils';
-import { StackCardProps, ApiOptions } from '@/types/types';
+import { StackCardProps, ApiOptions, IntrospectionProps } from '@/types/types';
 import StackCardMenu from './StackCardMenu';
 import EditIcon from '@mui/icons-material/Edit';
 import AppContext from '@/context/AppContext';
@@ -17,17 +17,13 @@ const StackCard: FC<StackCardProps> = ({ stack }) => {
   const appContext = useContext(AppContext);
   const { setFormOpen, setFormType, setShowStackIntrospection, sessionUser } = appContext;
 
-  const currentShowStackIntrospection = (introspection_id: number) => {
-    if (stack.introspection) {
-      return stack.introspection.find((introspection) => introspection && introspection.id === introspection_id)
-    }
-  }
-  const handleFormOpen = (introspection_id: number) => {
+  const handleFormOpen = () => {
     introspectionValue && setShowStackIntrospection(introspectionValue);
     setFormOpen(true);
     setFormType('updateStackIntrospection');
   }
-  const [introspectionValue, setIntrospection] = useState<any>([]);
+
+  const [introspectionValue, setIntrospectionValue] = useState<IntrospectionProps>(undefined);
 
   useEffect(() => {
     const fetchIntrospection = async () => {
@@ -44,15 +40,13 @@ const StackCard: FC<StackCardProps> = ({ stack }) => {
 
       try {
         const response = await axios.get(url, options);
-        console.log(response.data);
         return response.data;
       } catch (error) {
-        console.log(error);
         // throw new Error(`${JSON.stringify(error)}`);
       }
     }
     fetchIntrospection().then(res => {
-      setIntrospection(res);
+      setIntrospectionValue(res);
     });
   }, []);
 
@@ -71,14 +65,16 @@ const StackCard: FC<StackCardProps> = ({ stack }) => {
           <div className='flex items-center mr-4'><FavoriteBorderIcon className='text-gray-400 text-[20px] mr-1'/> 0</div>
           <div className='flex items-center'><BookmarkBorderIcon className='text-gray-400 text-[20px] mr-1'/> 0</div>
         </div>
-        <div className='mt-4'>
-         <div key={introspectionValue} className='bg-blue-500 px-6 py-2 rounded-full flex justify-between items-center mt-2'>
-            <span className='text-white text-sm font-bold'>反省</span>
-            <EditIcon className='text-[20px] text-white cursor-pointer' onClick={() => handleFormOpen(introspectionValue.id)} />
+        {introspectionValue &&
+          <div className='mt-4'>
+            <div key={introspectionValue.id} className='bg-blue-500 px-6 py-2 rounded-full flex justify-between items-center mt-2'>
+              <span className='text-white text-sm font-bold'>反省</span>
+              <EditIcon className='text-[20px] text-white cursor-pointer' onClick={handleFormOpen} />
+            </div>
           </div>
-        </div>
+        }
       </div>
-      <StackCardMenu />
+      <StackCardMenu stack_id={stack.id} />
     </div>
   )
 }

--- a/components/molecules/StackCardMenu.tsx
+++ b/components/molecules/StackCardMenu.tsx
@@ -5,16 +5,17 @@ import LinearScaleIcon from '@mui/icons-material/LinearScale';
 import Button from '@mui/material/Button';
 import AppContext from '@/context/AppContext';
 
-const StackCardMenu: FC = () => {
+const StackCardMenu: FC<{stack_id: number}> = ({ stack_id }) => {
   const appContext = useContext(AppContext);
-  const { setFormType, setFormOpen } = appContext;
+  const { setFormType, setFormOpen, setIntrospectionFormData } = appContext;
 
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
-  const handleFormOpenButton = () => {
+  const handleFormOpenButton = (stack_id: number) => {
+    setIntrospectionFormData({evaluation: 0, reason: "", keeps: [], problems: [], tries: [], stack_id: stack_id})
     setFormType('createStackIntrospection');
     setFormOpen(true);
     setAnchorEl(null);
@@ -50,7 +51,7 @@ const StackCardMenu: FC = () => {
           horizontal: 'left',
         }}
       >
-        <MenuItem onClick={handleFormOpenButton}>反省を追加</MenuItem>
+        <MenuItem onClick={() => handleFormOpenButton(stack_id)}>反省を追加</MenuItem>
       </Menu>
     </>
   )

--- a/context/AppContext.tsx
+++ b/context/AppContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, Dispatch, SetStateAction } from "react";
-import { FormType, IntrospectionProps, sessionUser } from "@/types/types";
+import { FormType, IntrospectionFormDataParams, IntrospectionProps, sessionUser } from "@/types/types";
 
 type AppContextProps = {
   drawerOpen: boolean;
@@ -17,7 +17,9 @@ type AppContextProps = {
   showStackIntrospection: IntrospectionProps;
   setShowStackIntrospection: Dispatch<SetStateAction<IntrospectionProps>>;
   sessionUser: sessionUser;
-  setSessionUser: React.Dispatch<React.SetStateAction<sessionUser>>
+  setSessionUser: React.Dispatch<React.SetStateAction<sessionUser>>;
+  introspectionFormData: IntrospectionFormDataParams;
+  setIntrospectionFormData: Dispatch<SetStateAction<IntrospectionFormDataParams>>,
 }
 
 const AppContext = createContext<AppContextProps>({
@@ -37,6 +39,8 @@ const AppContext = createContext<AppContextProps>({
   setShowStackIntrospection: () => {},
   sessionUser: undefined,
   setSessionUser: () => {},
+  introspectionFormData: {evaluation: 0, reason: "", keeps: [], problems: [], tries: []},
+  setIntrospectionFormData: () => {}
 }) 
 
 export default AppContext

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,7 +3,7 @@ import '../styles/globals.css'
 import "tailwindcss/tailwind.css";
 import type { AppProps } from 'next/app'
 import AppContext from '@/context/AppContext';
-import { FormType, IntrospectionProps, sessionUser } from '@/types/types';
+import { FormType, IntrospectionFormDataParams, IntrospectionProps, sessionUser } from '@/types/types';
 
 function MyApp({ Component, pageProps }: AppProps) {
 
@@ -28,6 +28,8 @@ function MyApp({ Component, pageProps }: AppProps) {
   const [showStackIntrospection, setShowStackIntrospection] = React.useState<IntrospectionProps|undefined>(undefined)
   const [sessionUser, setSessionUser] = React.useState<sessionUser>(undefined);
 
+  const [introspectionFormData, setIntrospectionFormData] = React.useState<IntrospectionFormDataParams>({evaluation: 0, reason: "", keeps: [], problems: [], tries: []})
+
   return (
     <AppContext.Provider 
       value={{
@@ -47,6 +49,8 @@ function MyApp({ Component, pageProps }: AppProps) {
         setShowStackIntrospection: setShowStackIntrospection,
         sessionUser: sessionUser,
         setSessionUser: setSessionUser,
+        introspectionFormData: introspectionFormData,
+        setIntrospectionFormData: setIntrospectionFormData,
       }}
     >
       <Component {...pageProps} />

--- a/types/types.ts
+++ b/types/types.ts
@@ -127,14 +127,9 @@ export type TextInputProps = ControlProps & {
   value?: string | number
 }
 
-export type IntrospectionProps = {
+export type IntrospectionProps = StacksIntrospectionRequestBody & {
   id: number;
   stack_id: number;
-  evaluation: number;
-  reason: string;
-  keeps: KeepAndProblemAndTryPoint[];
-  problems: KeepAndProblemAndTryPoint[];
-  tries: KeepAndProblemAndTryPoint[];
 } | undefined;
 
 export type StackProps = {
@@ -194,4 +189,8 @@ export type Team = {
   name: string;
   created_at: string;
   updated_at: string;
+}
+
+export type IntrospectionFormDataParams = StacksIntrospectionRequestBody & {
+  stack_id?: number
 }


### PR DESCRIPTION
## Epic
[本番環境で基本的な機能が使えるようになっている](https://app.asana.com/0/1204548322306328/1205352883161224/f)

## PBI
[積み上げの反省を作成できるようにする（APIテスト）](https://app.asana.com/0/1204548322306328/1205582673581813/f)
[積み上げの反省を閲覧できるようにする（APIテスト）](https://app.asana.com/0/1204548322306328/1205582673581811/f)

## OpenAPI
なし

## 対象画面キャプチャ
https://github.com/mnmuu8/skill-climbing-frontend/assets/121008362/ac93020e-d0f4-4843-8983-07db2b4024c1

## やったこと
- 積み上げ反省の閲覧
- 積み上げ反省の作成

## このPRでやらないこと
- リアルタイムの更新（時間かかるし別チケット）
- バリデーション（TextInputコンポーネントを大幅に変更する必要あり、全フォーム変更のタイミングで実装）

## 動作確認
- [x] 確認済み

## その他
なし